### PR TITLE
fixed libmozjs

### DIFF
--- a/remnux/config/spidermonkey.sls
+++ b/remnux/config/spidermonkey.sls
@@ -1,9 +1,9 @@
 include:
-  - remnux.packages.libmozjs-24-bin
+  - remnux.packages.libmozjs-52-0
 
 symlink-spidermonkey:
   file.symlink:
     - name: /usr/bin/js
     - target: /usr/bin/js24
     - watch:
-      - pkg: remnux-packages-libmozjs-24-bin
+      - pkg: libmozjs-52-0

--- a/remnux/packages/init.sls
+++ b/remnux/packages/init.sls
@@ -40,7 +40,7 @@ include:
   - remnux.packages.libfuzzy-dev
   - remnux.packages.libjpeg-dev
   - remnux.packages.libjpeg8-dev
-  - remnux.packages.libmozjs-24-bin
+  - remnux.packages.libmozjs-52-0
   - remnux.packages.libncurses
   # - remnux.packages.libolecf-utils
   - remnux.packages.libsqlite3-dev
@@ -177,7 +177,6 @@ remnux-packages:
       - sls: remnux.packages.libfuzzy-dev
       - sls: remnux.packages.libjpeg-dev
       - sls: remnux.packages.libjpeg8-dev
-      - sls: remnux.packages.libmozjs-24-bin
       - sls: remnux.packages.libncurses
       # - sls: remnux.packages.libolecf-utils
       - sls: remnux.packages.libsqlite3-dev

--- a/remnux/packages/libmozjs-24-bin.sls
+++ b/remnux/packages/libmozjs-24-bin.sls
@@ -1,3 +1,0 @@
-remnux-packages-libmozjs-24-bin:
-  pkg.installed:
-    - name: libmozjs-24-bin

--- a/remnux/packages/libmozjs-52-0.sls
+++ b/remnux/packages/libmozjs-52-0.sls
@@ -1,0 +1,2 @@
+libmozjs-52-0:
+  pkg.installed


### PR DESCRIPTION
Fix for:

migration of python-software-properties to software-properties-common 

migration of graphviz-dev to libgraphviz-dev
see: https://packages.ubuntu.com/search?keywords=graphviz-dev


